### PR TITLE
debian: properly configure interfaces

### DIFF
--- a/elements/debootstrap/install.d/10-debian-networking
+++ b/elements/debootstrap/install.d/10-debian-networking
@@ -26,6 +26,7 @@ echo $DISTRO_NAME > /etc/hostname
 
 # cloud images expect eth0 and eth1 to use dhcp.
 mkdir -p /etc/network/interfaces.d
+echo "source /etc/network/interfaces.d/*" >> /etc/network/interfaces
 for interface in eth0 eth1; do
     cat << EOF | tee /etc/network/interfaces.d/$interface
 auto $interface


### PR DESCRIPTION
interfaces are not configured at all because specific interface files
are created but not sourced. This will result in the VMs running with
the loopback interface only

This is a regression, the problem was already fixed in the past, see commit
b822581d88d5f9ec2080cb2eb6a07851f3b95e73