### PR TITLE
updating Memory calculation to convert GB to MB

### DIFF
--- a/elements/ironic-discoverd-ramdisk/init.d/80-ironic-discoverd-ramdisk
+++ b/elements/ironic-discoverd-ramdisk/init.d/80-ironic-discoverd-ramdisk
@@ -44,7 +44,7 @@ CPU_ARCH=$(lscpu | grep Architecture | awk '{ print $2 }')
 update ".cpu_arch = \"$CPU_ARCH\""
 
 RAM=0
-for i in $(dmidecode --type memory | grep Size | awk '{ print $2; }' | grep -E '[0-9]+');
+for i in $(dmidecode --type memory | awk '($0~/Size/ && $2~/[0-9]/) { ($3~/GB/) ? size=$2*1024 : size=$2; { print size; }}'); 
 do
     RAM=$(( RAM + $i ));
 done


### PR DESCRIPTION
DMI Decode interprets things in GB as opposed to MB.  Ironic believes this value to be MB, so the value must be manually corrected post-introspection.  This update should convert the value to MB prior to introspection/discovery.