### PR TITLE
Avoid disabling rhel-7-server-rh-common-rpms

### DIFF
--- a/elements/rhel-common/pre-install.d/00-rhel-registration
+++ b/elements/rhel-common/pre-install.d/00-rhel-registration
@@ -110,8 +110,6 @@ case "${REG_METHOD:-}" in
         subscription-manager register $opts
         echo "Enabling repos: $user_repos"
         subscription-manager $repos
-        echo "Disabling satellite repo because it is no longer needed"
-        subscription-manager repos --disable ${satellite_repo}
         ;;
     disable)
         echo "Disabling RHEL registration"


### PR DESCRIPTION
while using disk-image-builder for building overcloud images for TripleO using RDO, this repository is (in my opinion) wrongly disabled because contains certain dependencies needed by RDO packages.
Example: python-cheetah is required for python-nova, but is not available through RDO repository but only from rhel-7-server-rh-common-rpms