### PR TITLE
elements/gentoo: use dedicated tmpdir for gpg homedir

### DIFF
--- a/elements/gentoo/root.d/10-gentoo-image
+++ b/elements/gentoo/root.d/10-gentoo-image
@@ -79,7 +79,7 @@ else
     # https://dev.gentoo.org/~dolsen/releases/keyrings/gentoo-keys-*.tar.xz
     # http://distfiles.gentoo.org/distfiles/gentoo-keys-*.tar.xz
     GPGDIR=$(mktemp -d -t)
-    gpg --no-default-keyring --keyring "${GPGDIR}"/gentookeys.gpg --import "${TMP_HOOKS_PATH}"/extra-data.d/gentoo-releng.gpg
+    gpg --no-default-keyring --homedir "${GPGDIR}" --keyring "${GPGDIR}"/gentookeys.gpg --import "${TMP_HOOKS_PATH}"/extra-data.d/gentoo-releng.gpg
     # check the sig file
     gpgv --keyring "${GPGDIR}"/gentookeys.gpg "${CACHED_SIGNATURE_FILE}"
     if [[ "${?}" != 0 ]]; then


### PR DESCRIPTION
This adds a custom --homedir to gpg in order to use the dedicated
temporary directory instead of the default one for current user.