### PR TITLE
elements/centos7 capability to use proxy for DIB_DISTRIBUTION_MIRROR

### DIFF
--- a/diskimage_builder/elements/centos7/README.rst
+++ b/diskimage_builder/elements/centos7/README.rst
@@ -13,6 +13,12 @@ DIB_DISTRIBUTION_MIRROR:
                  the directory containing the ``5/6/7`` directories.
    :Example: ``DIB_DISTRIBUTION_MIRROR=http://amirror.com/centos``
 
+DIB_DISTRIBUTION_MIRROR_PROXY:
+   :Required: No
+   :Default: None
+   :Description: Specify a proxy to reach the specified CentOS Yum mirror,
+   :Example: ``DIB_DISTRIBUTION_MIRROR_PROXY=http://proxyaddr:3128``
+
 DIB_CLOUD_IMAGES
   :Required: No
   :Description: Set the desired URL to fetch the images from.  ppc64le:

--- a/diskimage_builder/elements/centos7/pre-install.d/01-set-centos-mirror
+++ b/diskimage_builder/elements/centos7/pre-install.d/01-set-centos-mirror
@@ -12,4 +12,8 @@ DIB_DISTRIBUTION_MIRROR=${DIB_DISTRIBUTION_MIRROR:-}
 
 # Only set the mirror for the Base, Extras and Updates repositories
 # The others arn't enabled and do not exist on all mirrors
-sed -e "s|^#baseurl=http://mirror.centos.org/centos|baseurl=$DIB_DISTRIBUTION_MIRROR|;/^mirrorlist=/d" -i /etc/yum.repos.d/CentOS-Base.repo
+if [ -n "$DIB_DISTRIBUTION_MIRROR_PROXY" ];then
+    sed -e "s|^#baseurl=http://mirror.centos.org/centos|proxy=$DIB_DISTRIBUTION_MIRROR_PROXY\nbaseurl=$DIB_DISTRIBUTION_MIRROR|;/^mirrorlist=/d" -i /etc/yum.repos.d/CentOS-Base.repo
+else
+    sed -e "s|^#baseurl=http://mirror.centos.org/centos|baseurl=$DIB_DISTRIBUTION_MIRROR|;/^mirrorlist=/d" -i /etc/yum.repos.d/CentOS-Base.repo
+fi


### PR DESCRIPTION
User might want to specify a proxy to reach the Mirror