### PR TITLE
Use --force-yes with apt-get install

### DIFF
--- a/diskimage_builder/elements/debian-minimal/root.d/75-debian-minimal-baseinstall
+++ b/diskimage_builder/elements/debian-minimal/root.d/75-debian-minimal-baseinstall
@@ -75,4 +75,4 @@ else
     exit 1
 fi
 
-$apt_get install -y $to_install
+$apt_get install --force-yes -y $to_install


### PR DESCRIPTION
This step fails while installing systemd-sysv due to sysvinit (essential) being ripped out.