### PR TITLE
epel-release for 7 is no longer in x86_64 dir

### DIFF
--- a/elements/epel/pre-install.d/05-rpm-epel-release
+++ b/elements/epel/pre-install.d/05-rpm-epel-release
@@ -16,7 +16,7 @@ BASE_URL=${DIB_EPEL_MIRROR:-https://dl.fedoraproject.org/pub/epel}
 case "$DISTRO_NAME" in
     rhel7|centos7)
         RELEASE=7
-        URL=$BASE_URL/$RELEASE/x86_64/e/
+        URL=$BASE_URL/$RELEASE/x86_64/Packages/e/
         ;;
     rhel|centos)
         RELEASE=6


### PR DESCRIPTION
Which it is for EL6..