### PR TITLE
Fix hardcoded scriptname in echo function

### DIFF
--- a/diskimage_builder/lib/disk-image-create
+++ b/diskimage_builder/lib/disk-image-create
@@ -218,7 +218,7 @@ if [ "$IS_RAMDISK" == "1" ]; then
   source $_LIB/ramdisk-functions
 fi
 
-echo "diskimage-builder version $(show_version)"
+echo "${SCRIPTNAME} version $(show_version)"
 
 # If no elements are specified theres no way we can succeed
 if [ -z "$*" ]; then


### PR DESCRIPTION
Change hardcoded scriptname in echo function to ${SCRIPTNAME} var.

OLD:
[root@benchmarking ~]# disk-image-create 
[root@benchmarking ~]# 2018-02-13 16:45:56.147 | diskimage-builder version 2.10.2

NEW:
[root@benchmarking ~]# disk-image-create 
[root@benchmarking ~]# 2018-02-13 16:45:56.147 | disk-image-create version 2.10.2