### PR TITLE
FIX: find: 'Permission denied' on certain images

### DIFF
--- a/diskimage_builder/elements/dpkg/root.d/50-block-apt-translations
+++ b/diskimage_builder/elements/dpkg/root.d/50-block-apt-translations
@@ -14,4 +14,4 @@ Acquire::Languages "none";
 EOF
 
 # And now make sure that we don't fall foul of Debian bug 641967
-sudo find $TARGET_ROOT/var/lib/apt/lists/ -path $TARGET_ROOT/var/lib/apt/lists/partial -prune -o -type f -name '*_i18n_Translation-*' -print -exec sudo rm -f {} +
+sudo find $TARGET_ROOT/var/lib/apt/lists/ -path $TARGET_ROOT/var/lib/apt/lists/partial -prune -o -type f -name '*_i18n_Translation-*' -print -exec rm -f {} +

--- a/diskimage_builder/elements/dpkg/root.d/50-block-apt-translations
+++ b/diskimage_builder/elements/dpkg/root.d/50-block-apt-translations
@@ -14,4 +14,4 @@ Acquire::Languages "none";
 EOF
 
 # And now make sure that we don't fall foul of Debian bug 641967
-find $TARGET_ROOT/var/lib/apt/lists/ -path $TARGET_ROOT/var/lib/apt/lists/partial -prune -o -type f -name '*_i18n_Translation-*' -print -exec sudo rm -f {} +
+sudo find $TARGET_ROOT/var/lib/apt/lists/ -path $TARGET_ROOT/var/lib/apt/lists/partial -prune -o -type f -name '*_i18n_Translation-*' -print -exec sudo rm -f {} +


### PR DESCRIPTION
Fixes 'find' failing when permissions are too restrictive, e.g. on Ubuntu Xenial:
```
+ /tmp/image.Vi9ePdqy/hooks/root.d/60-block-apt-translations
+ set -eu
+ set -o pipefail
+ '[' -n /tmp/image.Vi9ePdqy/mnt ']'
+ sudo dd of=/tmp/image.Vi9ePdqy/mnt/etc/apt/apt.conf.d/95no-translations
0+1 records in
0+1 records out
27 bytes copied, 3.2684e-05 s, 826 kB/s
+ find /tmp/image.Vi9ePdqy/mnt/var/lib/apt/lists/ -type f -name '*_i18n_Translation-*' -exec sudo rm -f '{}' +
find: '/tmp/image.Vi9ePdqy/mnt/var/lib/apt/lists/partial': Permission denied```