### PR TITLE
Changes Added to Accomodate SWAP Disk..

### DIFF
--- a/diskimage_builder/block_device/level2/mkfs.py
+++ b/diskimage_builder/block_device/level2/mkfs.py
@@ -102,11 +102,14 @@ class FilesystemNode(NodeBase):
         return (edge_from, edge_to)
 
     def create(self):
-        cmd = ["mkfs"]
-
-        cmd.extend(['-t', self.type])
-        if self.opts:
+        if self.type in ('swap'):
+          cmd = ["mkswap"]
+	else:
+          cmd = ["mkfs"]
+          cmd.extend(['-t', self.type])
+          if self.opts:
             cmd.extend(self.opts)
+
 
         if self.type in ('vfat', 'fat'):
             cmd.extend(["-n", self.label])


### PR DESCRIPTION
- mkfs:
    name: mkfs_swap
    base: swap
    type: swap  <- Type is Swap {this does mkswap <dev>}
    mount:
      mount_point: swap <- Mount Point is Swap {swapon / swapoff <dev>}
      fstab:
        options: "defaults"
        dump-freq: 0
        fsck-passno: 0

I thought this should help, Though I understand we can give in elements. IMO I find this a better approach. Let me know your thoughts..

rgds
Balaji 