### PR TITLE
Fix baremetal iso building

### DIFF
--- a/diskimage_builder/elements/iso/cleanup.d/100-build-iso
+++ b/diskimage_builder/elements/iso/cleanup.d/100-build-iso
@@ -33,7 +33,7 @@ function build_efiboot_img() {
         cp $TMP_BOOTLOADER_DIR/shim.efi $TMP_BUILD_DIR/bootx64.efi
         cp $TMP_BOOTLOADER_DIR/grubx64.efi $TMP_BUILD_DIR/grubx64.efi
     else
-        cp $TMP_BOOTLOADER_DIR/shim.efi.signed $TMP_BUILD_DIR/bootx64.efi
+        cp $TMP_BOOTLOADER_DIR/shimx64.efi.signed $TMP_BUILD_DIR/bootx64.efi
         cp $TMP_BOOTLOADER_DIR/grubx64.efi.signed $TMP_BUILD_DIR/grubx64.efi
     fi
 
@@ -61,7 +61,8 @@ function build_iso() {
 
     SCRIPTNAME=$(basename $0)
     SCRIPTDIR=$(dirname $0)
-    MKISOFS="/usr/bin/mkisofs"
+    # MKISOFS="/usr/bin/mkisofs"
+    MKISOFS="/usr/bin/genisoimage"
     if [ $DISTRO_NAME = "fedora" ]; then
         EFI_BOOT_DIR="EFI/fedora"
         EXTRA_KERNEL_PARAMS="usbcore.autosuspend=-1"
@@ -139,7 +140,6 @@ END_CONFIG
     $MKISOFS -r -V "VMEDIA_BOOT_ISO" -cache-inodes -J -l \
     -b isolinux/isolinux.bin  -no-emul-boot \
     -boot-load-size 4 -boot-info-table \
-    -eltorito-alt-boot -e isolinux/efiboot.img \
     -no-emul-boot -o $OUTPUT_FILENAME $TMP_IMAGE_DIR
 
 }

--- a/diskimage_builder/elements/iso/post-install.d/01-copy-bootloaders
+++ b/diskimage_builder/elements/iso/post-install.d/01-copy-bootloaders
@@ -19,7 +19,7 @@ if [ $DISTRO_NAME = "fedora" ]; then
 #debian
 elif [ $DISTRO_NAME = "debian" ]; then
     GRUB_FILE="/usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed"
-    SHIM_FILE="/usr/lib/shim/shim.efi.signed"
+    SHIM_FILE="/usr/lib/shim/shimx64.efi.signed"
     SYSLINUX_FILE="/usr/lib/ISOLINUX/isolinux.bin"
     LDLINUX_FILE="/usr/lib/syslinux/modules/bios/ldlinux.c32"
 #rhel7
@@ -31,7 +31,7 @@ elif [ $DISTRO_NAME = "rhel7" ]; then
 #ubuntu
 else
     GRUB_FILE="/usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed"
-    SHIM_FILE="/usr/lib/shim/shim.efi.signed"
+    SHIM_FILE="/usr/lib/shim/shimx64.efi.signed"
     SYSLINUX_FILE="/usr/lib/syslinux/isolinux.bin"
     LDLINUX_FILE="/usr/lib/syslinux/ldlinux.c32"
 fi

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ commands=
     python setup.py test --slowest --testr-args='{posargs}'
 passenv=
     DUMP_CONFIG_GRAPH
+    DIB_IMAGE_ROOT_FS_UUID
 
 [testenv:bindep]
 deps = bindep
@@ -32,6 +33,8 @@ commands = pylint --rcfile pylint.cfg diskimage_builder
 [testenv:venv]
 basepython = python3
 commands = {posargs}
+passenv=
+    DIB_IMAGE_ROOT_FS_UUID
 
 [testenv:func]
 envdir = {toxworkdir}/venv


### PR DESCRIPTION
I'm trying the [iso option of diskimage-builder](https://docs.openstack.org/diskimage-builder/latest/elements/iso/README.html) using the following command

```shell
export DIB_IMAGE_ROOT_FS_UUID=$(uuidgen -r)
tox -e venv -- disk-image-create -o /images/my_image iso debian baremetal
```

but I keep hitting errors like

```shell
cannot stat '/usr/lib/shim/shim.efi.signed'
```

Also `mkisofs` can't be downloaded for decent distro's AFAIK and the alternatives don't support `-eltorito-alt-boot -e isolinux/efiboot.img`.

Would like to know if the `iso` option is considered deprecated or that I'm doing something wrong (very likely).