### PR TITLE
mount command fails with unknown filesystem type 'LVM2_member'

### DIFF
--- a/diskimage_builder/elements/redhat-common/bin/extract-image
+++ b/diskimage_builder/elements/redhat-common/bin/extract-image
@@ -93,7 +93,7 @@ function extract_image() {
                 MOUNTOPTS=""
             fi
 
-            sudo mount $MOUNTOPTS /dev/mapper/$ROOT_LOOPDEV $WORKING/mnt
+            sudo mount $MOUNTOPTS /dev/mapper/$ROOT_LOOPDEV $WORKING/mnt #fails if source image from which I create another custom one has LVM layout implemented, please see the DEBUG output in the description of this commit 
             EACTION="sudo umount -f $WORKING/mnt ; $EACTION"
             trap "$EACTION" EXIT
 


### PR DESCRIPTION
2020-02-17 17:41:11.482 | + /tmp/dib_build.ywdzKMIw/hooks/bin/extract-image:extract_image:22                 :   '[' -n '' -a -f /home/stack/.cache/image-create/centos7-standard.qcow2.tgz ']'
2020-02-17 17:41:11.486 | + /tmp/dib_build.ywdzKMIw/hooks/bin/extract-image:extract_image:25                 :   '[' -z /home/stack/images/centos7-standard.qcow2 ']'
2020-02-17 17:41:11.488 | + /tmp/dib_build.ywdzKMIw/hooks/bin/extract-image:extract_image:42                 :   '[' '!' -f /home/stack/.cache/image-create/centos7-standard.qcow2.tgz -o /home/stack/images/centos7-standard.qcow2 -nt /home/stack/.cache/image-create/centos7-standard.qcow2.tgz ']'
2020-02-17 17:41:11.491 | + /tmp/dib_build.ywdzKMIw/hooks/bin/extract-image:extract_image:44                 :   echo 'Repacking base image as tarball.'
2020-02-17 17:41:11.491 | Repacking base image as tarball.
2020-02-17 17:41:11.495 | ++ /tmp/dib_build.ywdzKMIw/hooks/bin/extract-image:extract_image:46                 :   mktemp --tmpdir=/tmp -d
2020-02-17 17:41:11.499 | + /tmp/dib_build.ywdzKMIw/hooks/bin/extract-image:extract_image:46                 :   WORKING=/tmp/tmp.Vwn3JFPikt
2020-02-17 17:41:11.502 | + /tmp/dib_build.ywdzKMIw/hooks/bin/extract-image:extract_image:47                 :   EACTION='rm -r /tmp/tmp.Vwn3JFPikt'
2020-02-17 17:41:11.505 | + /tmp/dib_build.ywdzKMIw/hooks/bin/extract-image:extract_image:48                 :   trap 'rm -r /tmp/tmp.Vwn3JFPikt' EXIT
2020-02-17 17:41:11.508 | + /tmp/dib_build.ywdzKMIw/hooks/bin/extract-image:extract_image:49                 :   echo 'Working in /tmp/tmp.Vwn3JFPikt'
2020-02-17 17:41:11.508 | Working in /tmp/tmp.Vwn3JFPikt
2020-02-17 17:41:11.512 | ++ /tmp/dib_build.ywdzKMIw/hooks/bin/extract-image:extract_image:51                 :   mktemp --tmpdir=/tmp/tmp.Vwn3JFPikt XXXXXX.raw
2020-02-17 17:41:11.516 | + /tmp/dib_build.ywdzKMIw/hooks/bin/extract-image:extract_image:51                 :   RAW_FILE=/tmp/tmp.Vwn3JFPikt/DH2rEQ.raw
2020-02-17 17:41:11.519 | + /tmp/dib_build.ywdzKMIw/hooks/bin/extract-image:extract_image:53                 :   '[' ow2 == .xz ']'
2020-02-17 17:41:11.522 | + /tmp/dib_build.ywdzKMIw/hooks/bin/extract-image:extract_image:60                 :   qemu-img convert -f qcow2 -O raw /home/stack/images/centos7-standard.qcow2 /tmp/tmp.Vwn3JFPikt/DH2rEQ.raw
2020-02-17 17:41:28.792 | ++ /tmp/dib_build.ywdzKMIw/hooks/bin/extract-image:extract_image:62                 :   wc -l
2020-02-17 17:41:28.792 | ++ /tmp/dib_build.ywdzKMIw/hooks/bin/extract-image:extract_image:62                 :   sudo kpartx -l /tmp/tmp.Vwn3JFPikt/DH2rEQ.raw
2020-02-17 17:41:28.792 | ++ /tmp/dib_build.ywdzKMIw/hooks/bin/extract-image:extract_image:62                 :   awk '/loop[0-9]+p/'
2020-02-17 17:41:28.858 | + /tmp/dib_build.ywdzKMIw/hooks/bin/extract-image:extract_image:62                 :   ROOT_PARTITION=p3
2020-02-17 17:41:28.864 | + /tmp/dib_build.ywdzKMIw/hooks/bin/extract-image:extract_image:63                 :   sudo udevadm settle
2020-02-17 17:41:28.891 | + /tmp/dib_build.ywdzKMIw/hooks/bin/extract-image:extract_image:67                 :   sudo losetup -f
2020-02-17 17:41:28.907 | /dev/loop1
2020-02-17 17:41:28.914 | ++ /tmp/dib_build.ywdzKMIw/hooks/bin/extract-image:extract_image:72                 :   sudo kpartx -av /tmp/tmp.Vwn3JFPikt/DH2rEQ.raw
2020-02-17 17:41:28.918 | ++ /tmp/dib_build.ywdzKMIw/hooks/bin/extract-image:extract_image:72                 :   awk '/loop[0-9]+p3/ {print $3}'
2020-02-17 17:41:29.011 | + /tmp/dib_build.ywdzKMIw/hooks/bin/extract-image:extract_image:72                 :   ROOT_LOOPDEV=loop1p3
2020-02-17 17:41:29.020 | + /tmp/dib_build.ywdzKMIw/hooks/bin/extract-image:extract_image:74                 :   '[' -f /.dockerenv ']'
2020-02-17 17:41:29.020 | + /tmp/dib_build.ywdzKMIw/hooks/bin/extract-image:extract_image:77                 :   timeout 5 sh -c 'while ! [ -e /dev/mapper/loop1p3 ]; do sleep 1; done'
2020-02-17 17:41:29.031 | + /tmp/dib_build.ywdzKMIw/hooks/bin/extract-image:extract_image:81                 :   EACTION='sudo kpartx -d /tmp/tmp.Vwn3JFPikt/DH2rEQ.raw ; rm -r /tmp/tmp.Vwn3JFPikt'
2020-02-17 17:41:29.041 | + /tmp/dib_build.ywdzKMIw/hooks/bin/extract-image:extract_image:82                 :   trap 'sudo kpartx -d /tmp/tmp.Vwn3JFPikt/DH2rEQ.raw ; rm -r /tmp/tmp.Vwn3JFPikt' EXIT
2020-02-17 17:41:29.044 | + /tmp/dib_build.ywdzKMIw/hooks/bin/extract-image:extract_image:83                 :   mkdir /tmp/tmp.Vwn3JFPikt/mnt
2020-02-17 17:41:29.051 | ++ /tmp/dib_build.ywdzKMIw/hooks/bin/extract-image:extract_image:84                 :   sudo blkid -o value -s TYPE /dev/mapper/loop1p3
2020-02-17 17:41:29.085 | + /tmp/dib_build.ywdzKMIw/hooks/bin/extract-image:extract_image:84                 :   '[' xfs = LVM2_member ']'
2020-02-17 17:41:29.089 | + /tmp/dib_build.ywdzKMIw/hooks/bin/extract-image:extract_image:88                 :   MOUNTOPTS=
2020-02-17 17:41:29.093 | + /tmp/dib_build.ywdzKMIw/hooks/bin/extract-image:extract_image:91                 :   sudo mount /dev/mapper/loop1p3 /tmp/tmp.Vwn3JFPikt/mnt
2020-02-17 17:41:29.124 | mount: unknown filesystem type 'LVM2_member'
2020-02-17 17:41:29.129 | ++ /tmp/dib_build.ywdzKMIw/hooks/bin/extract-image:extract_image:1                  :   sudo kpartx -d /tmp/tmp.Vwn3JFPikt/DH2rEQ.raw
2020-02-17 17:41:29.182 | loop deleted : /dev/loop1
2020-02-17 17:41:29.189 | ++ /tmp/dib_build.ywdzKMIw/hooks/bin/extract-image:extract_image:1                  :   rm -r /tmp/tmp.Vwn3JFPikt