### PR TITLE
Adding enable-services element for enabling services in the post-install stage

### DIFF
--- a/diskimage_builder/elements/enable-services/README.rst
+++ b/diskimage_builder/elements/enable-services/README.rst
@@ -2,10 +2,8 @@
 enable-services
 ==========
 
-Enables services (like networking) for the generated cloud image.
-Currently only supports Gentoo, and only OpenRC's default runlevel, as well as only systemd Service units.  More may come later.
-If you enable this element, and do not specify DIB_ENABLE_SERVICES, it does nothing.
-If you enable this element on any distro that is not Gentoo, it also does nothing.
+Enables services inside the generated cloud image.
+Currently only supports Gentoo, and only OpenRC's default runlevel, as well as only systemd service units.
 
 Environment Variables
 ---------------------
@@ -14,3 +12,4 @@ DIB_ENABLE_SERVICES:
   :Required: No
   :Default: Empty
   :Description: Enables services post-install for the generated cloud image.
+  :Example: DIB_ENABLE_SERVICES="systemd-networkd systemd-resolved"

--- a/diskimage_builder/elements/enable-services/README.rst
+++ b/diskimage_builder/elements/enable-services/README.rst
@@ -1,0 +1,16 @@
+==========
+enable-services
+==========
+
+Enables services (like networking) for the generated cloud image.
+Currently only supports Gentoo, and only OpenRC's default runlevel, as well as only systemd Service units.  More may come later.
+If you enable this element, and do not specify DIB_ENABLE_SERVICES, it does nothing.
+If you enable this element on any distro that is not Gentoo, it also does nothing.
+
+Environment Variables
+---------------------
+
+DIB_ENABLE_SERVICES:
+  :Required: No
+  :Default: Empty
+  :Description: Enables services post-install for the generated cloud image.

--- a/diskimage_builder/elements/enable-services/post-install.d/20-enable-services
+++ b/diskimage_builder/elements/enable-services/post-install.d/20-enable-services
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+# gentoo
+if [ "${DISTRO_NAME}" == "gentoo" ]; then
+  for service_name in "${DIB_ENABLE_SERVICES}"; do
+    if [[ "${DIB_INIT_SYSTEM}" == "openrc" ]]; then
+      rc-update add ${service_name} default
+    fi
+
+    if [[ "${DIB_INIT_SYSTEM}" == "systemd" ]]; then
+      systemctl enable ${service_name}.service
+    fi
+  done
+fi

--- a/diskimage_builder/elements/enable-services/post-install.d/20-enable-services
+++ b/diskimage_builder/elements/enable-services/post-install.d/20-enable-services
@@ -11,9 +11,7 @@ if [ "${DISTRO_NAME}" == "gentoo" ]; then
   for service_name in "${DIB_ENABLE_SERVICES}"; do
     if [[ "${DIB_INIT_SYSTEM}" == "openrc" ]]; then
       rc-update add ${service_name} default
-    fi
-
-    if [[ "${DIB_INIT_SYSTEM}" == "systemd" ]]; then
+    elif [[ "${DIB_INIT_SYSTEM}" == "systemd" ]]; then
       systemctl enable ${service_name}.service
     fi
   done


### PR DESCRIPTION
This is a feature-add to allow enabling of services in generated cloud images. 
It's very basic.  Only supports systemd service units, and openrc's default runlevel. 
Gentoo-only, but could be expanded for sure to other distros that may have a need. 