### PR TITLE
Switch from cp to mv when baking data into the raw disk image

### DIFF
--- a/diskimage_builder/lib/disk-image-create
+++ b/diskimage_builder/lib/disk-image-create
@@ -533,14 +533,7 @@ LOOPDEV=${IMAGE_BLOCK_DEVICE}
 # (IMAGE_BLOCK_DEVICE) and mounted all the partitions under
 # $TMP_BUILD_DIR/mnt for us.  We can now copy into the final image.
 
-# 'mv' is not usable here - especially when a top level directory
-# has the same name as a mount point of a partition.  If so, 'mv'
-# will complain:
-# mv: inter-device move failed: '...' to '...'; \
-#       unable to remove target: Device or resource busy
-# therefore a 'cp' and 'rm' approach is used.
-sudo cp -ra ${TMP_BUILD_DIR}/built/* $TMP_BUILD_DIR/mnt
-sudo rm -fr ${TMP_BUILD_DIR}/built/*
+sudo mv ${TMP_BUILD_DIR}/built/* $TMP_BUILD_DIR/mnt
 
 mount_proc_dev_sys
 run_d pre-finalise


### PR DESCRIPTION
When building diskimages and baking in large amounts of data, the data can exist
on the diskimage building machine essentially twice. When there is limited disk
space available on the machine, this becomes a problem.

An example of the error we encounter is:

```
INFO diskimage_builder.block_device.blockdevice [-] Wrote final block device config to [/tmp/dib_build.o9Cnu5kk/states/block-device/config.json]
INFO diskimage_builder.block_device.blockdevice [-] create() called
INFO diskimage_builder.block_device.level0.localloop [-] Create image file [/tmp/dib_image.sPaNBeoX/image0.raw]
INFO diskimage_builder.block_device.level0.localloop [-] loopdev attach
INFO diskimage_builder.block_device.utils [-] Calling [sudo losetup --show -f /tmp/dib_image.sPaNBeoX/image0.raw]
INFO diskimage_builder.block_device.level0.localloop [-] New block device [/dev/loop0]
INFO diskimage_builder.block_device.level1.partitioning [-] Creating partition on [image0] [/tmp/dib_image.sPaNBeoX/image0.raw]
INFO diskimage_builder.block_device.level1.mbr [-] Create MBR disk partitioning object
INFO diskimage_builder.block_device.level1.mbr [-] Partition absolute [2048] relative [0] length [596792704] absolute end [596795392]
INFO diskimage_builder.block_device.level1.mbr [-] Write partition entry blockno [0] entry [0] start [2048] length [596792704]
INFO diskimage_builder.block_device.utils [-] Calling [sudo sync]
INFO diskimage_builder.block_device.utils [-] Calling [sudo kpartx -uvs /dev/loop0]
INFO diskimage_builder.block_device.utils [-] Calling [sudo mkfs -t ext4 -O ^has_journal -L cloudimg-rootfs -U 8d77d8d3-ad5f-4dcc-a87b-ba0f3c43344e -q /dev/mapper/loop0p1]
INFO diskimage_builder.block_device.utils [-] Calling [sudo mkdir -p /tmp/dib_build.o9Cnu5kk/mnt/]
INFO diskimage_builder.block_device.level3.mount [-] Mounting [mount_mkfs_root] to [/tmp/dib_build.o9Cnu5kk/mnt/]
INFO diskimage_builder.block_device.utils [-] Calling [sudo mount /dev/mapper/loop0p1 /tmp/dib_build.o9Cnu5kk/mnt/]
INFO diskimage_builder.block_device.blockdevice [-] create() finished
INFO diskimage_builder.block_device.blockdevice [-] Getting value for [image-block-device]
INFO diskimage_builder.block_device.blockdevice [-] Getting value for [image-block-devices]
INFO diskimage_builder.block_device.blockdevice [-] Creating fstab
INFO diskimage_builder.block_device.utils [-] Calling [sudo mkdir -p /tmp/dib_build.o9Cnu5kk/built/etc]
INFO diskimage_builder.block_device.utils [-] Calling [sudo cp /tmp/dib_build.o9Cnu5kk/states/block-device/fstab /tmp/dib_build.o9Cnu5kk/built/etc/fstab]
cp: cannot create directory '/tmp/dib_build.o9Cnu5kk/mnt/var/cache/bazel/external/file': Structure needs cleaning
```

The proposed change removes the `cp` and `rm` approach in favour of a `mv`
approach. This should remove the need for the data to exist twice on the
machine and reduce the chances for the machine to run out of disk space.

An alternative approach is to use `rsync` instead of `mv`, which is added in this PR https://github.com/openstack/diskimage-builder/pull/31.