### PR TITLE
Force grub2-install to proceed when no secureboot in EL8/9

### DIFF
--- a/diskimage_builder/elements/bootloader/finalise.d/50-bootloader
+++ b/diskimage_builder/elements/bootloader/finalise.d/50-bootloader
@@ -331,7 +331,7 @@ else
                 $GRUBNAME --modules="$modules" --target=i386-pc $BOOT_DEV
                 # Set the x86_64 specific efi target for the generic
                 # installation below.
-                GRUB_OPTS="--target=x86_64-efi"
+                GRUB_OPTS="--force --target=x86_64-efi"
                 ;;
             # At this point, we don't need to override the target
             # for any other architectures.


### PR DESCRIPTION
In EL8/9 machines, grub2-install will not proceed if it can't see /boot/efi/efi/redhat, as it wants to use secure boot. This isn't appropriate for this use case, and thus --force is needed to bypass this.