### PR TITLE
Enable custom overlays for Gentoo element

### DIFF
--- a/diskimage_builder/elements/gentoo/README.rst
+++ b/diskimage_builder/elements/gentoo/README.rst
@@ -51,6 +51,10 @@ Notes:
   should put a space separated list of overlays.  The overlays must be in the
   official overlay list and must be git based.
 
+* You can enable custom overlays using the `GENTOO_CUSTOM_OVERLAYS` variable.  In it you
+  should put a space separated list of overlay tuples.  The tuples must of the
+  form `<reponame>:<sync-uri>`.  The overlays must be git based.
+
 * `GENTOO_EMERGE_ENV` is a bash array containing default environment
   variables for package install, you can override it with another bash array.
 

--- a/diskimage_builder/elements/gentoo/bin/install-packages
+++ b/diskimage_builder/elements/gentoo/bin/install-packages
@@ -26,15 +26,18 @@ set -o pipefail
 #             unset the environment to ensure default behavior.
 unset YACC LEX
 
+export GENTOO_ACCEPT_KEYWORDS=${GENTOO_ACCEPT_KEYWORDS:-"${ARCH}"}
+
 # env is not sourced with user specified package inclusions
 # set the default bash array if GENTOO_EMERGE_ENV is not defined as an array
 if ! declare -p GENTOO_EMERGE_ENV  2> /dev/null | grep -q '^declare \-a'; then
     declare -a GENTOO_EMERGE_ENV
-    GENTOO_EMERGE_ENV+=("USE=\"-build\"")
+    GENTOO_EMERGE_ENV+=("USE=\"-build dist-kernel\"")
     GENTOO_EMERGE_ENV+=("FEATURES=\"binpkg-multi-instance buildpkg parallel-fetch parallel-install\"")
     GENTOO_EMERGE_ENV+=("PKGDIR=\"/tmp/portage-pkgdir\"")
     GENTOO_EMERGE_ENV+=("DISTDIR=\"/tmp/portage-distdir\"")
     GENTOO_EMERGE_ENV+=("PORTDIR=\"/tmp/portage-portdir\"")
+    GENTOO_EMERGE_ENV+=("ACCEPT_KEYWORDS=\"${GENTOO_ACCEPT_KEYWORDS}\"")
     export GENTOO_EMERGE_ENV
 fi
 # iterate over the array, exporting each 'line'

--- a/diskimage_builder/elements/gentoo/environment.d/00-gentoo-envars.bash
+++ b/diskimage_builder/elements/gentoo/environment.d/00-gentoo-envars.bash
@@ -6,6 +6,7 @@ export GENTOO_PORTAGE_CLEANUP=${GENTOO_PORTAGE_CLEANUP:-'True'}
 export GENTOO_PYTHON_TARGETS=${GENTOO_PYTHON_TARGETS:-''}
 export GENTOO_OVERLAYS=${GENTOO_OVERLAYS:-''}
 export GENTOO_EMERGE_DEFAULT_OPTS=${GENTOO_EMERGE_DEFAULT_OPTS:-"--binpkg-respect-use --rebuilt-binaries=y --usepkg=y --with-bdeps=y --binpkg-changed-deps=y --quiet --jobs=2 --autounmask=n"}
+export GENTOO_ACCEPT_KEYWORDS=${GENTOO_ACCEPT_KEYWORDS:-"${ARCH}"}
 
 # NOTE(JayF): This defines the base gentoo profile version supported
 # in DIB. As gentoo is a rolling release distro, the older profiles
@@ -16,11 +17,12 @@ export GENTOO_PROFILE=${GENTOO_PROFILE:-$GENTOO_BASE_PROFILE}
 # set the default bash array if GENTOO_EMERGE_ENV is not defined as an array
 if ! declare -p GENTOO_EMERGE_ENV  2> /dev/null | grep -q '^declare \-a'; then
     declare -a GENTOO_EMERGE_ENV
-    GENTOO_EMERGE_ENV+=("USE=\"-build\"")
+    GENTOO_EMERGE_ENV+=("USE=\"-build dist-kernel\"")
     GENTOO_EMERGE_ENV+=("FEATURES=\"binpkg-multi-instance buildpkg parallel-fetch parallel-install\"")
     GENTOO_EMERGE_ENV+=("PKGDIR=\"/tmp/portage-pkgdir\"")
     GENTOO_EMERGE_ENV+=("DISTDIR=\"/tmp/portage-distdir\"")
     GENTOO_EMERGE_ENV+=("PORTDIR=\"/tmp/portage-portdir\"")
+    GENTOO_EMERGE_ENV+=("ACCEPT_KEYWORDS=\"${GENTOO_ACCEPT_KEYWORDS}\"")
     export GENTOO_EMERGE_ENV
 fi
 # iterate over the array, exporting each 'line'

--- a/diskimage_builder/elements/gentoo/post-install.d/99-cleanup
+++ b/diskimage_builder/elements/gentoo/post-install.d/99-cleanup
@@ -38,7 +38,12 @@ if [[ "${GENTOO_PORTAGE_CLEANUP}" != "False" ]]; then
     # remove the overlays
     if [[ ${GENTOO_OVERLAYS} != '' ]]; then
         for OVERLAY in ${GENTOO_OVERLAYS}; do
-            layman -d "${OVERLAY}"
+            eselect repository remove "${OVERLAY}"
+        done
+    fi
+    if [[ ${GENTOO_CUSTOM_OVERLAY} != '' ]]; then
+        for OVERLAY in ${GENTOO_CUSTOM_OVERLAYS}; do
+            eselect repository remove "${OVERLAY}"
         done
     fi
 fi

--- a/diskimage_builder/elements/gentoo/pre-install.d/02-gentoo-02-flags
+++ b/diskimage_builder/elements/gentoo/pre-install.d/02-gentoo-02-flags
@@ -12,6 +12,9 @@ mkdir -p /etc/portage/package.accept_keywords
 if [[ -f /etc/portage/package.keywords ]]; then
     mv /etc/portage/package.keywords /etc/portage/package.accept_keywords/prebuilt-1
 fi
+if [[ -z "${GENTOO_ACCEPT_KEYWORDS}" ]]; then
+    echo "ACCEPT_KEYWORDS=\"${GENTOO_ACCEPT_KEYWORDS}\"" >> /etc/portage/make.conf
+fi
 mkdir -p /etc/portage/package.mask
 mkdir -p /etc/portage/package.unmask
 mkdir -p /etc/portage/package.use

--- a/diskimage_builder/elements/gentoo/pre-install.d/02-gentoo-03-enable-overlays
+++ b/diskimage_builder/elements/gentoo/pre-install.d/02-gentoo-03-enable-overlays
@@ -25,6 +25,15 @@ if [[ ${GENTOO_OVERLAYS} != '' ]]; then
     set +e
     for OVERLAY in ${GENTOO_OVERLAYS}; do
         eselect repository enable "${OVERLAY}"
+        emaint sync -r "${OVERLAY}"
+    done
+    set -e
+
+    # enable the various custom overlays, ignore failures (overlay my already be enabled)
+    set +e
+    for OVERLAY in ${GENTOO_CUSTOM_OVERLAYS}; do
+        eselect repository add $(echo "${OVERLAY}" | sed 's/:/ git /' )
+        emaint sync -r $(echo "${OVERLAY}" | sed 's/:.*//' ) 
     done
     set -e
 


### PR DESCRIPTION
This enables adding custom overlays at build time when creating Gentoo VM images.  This is done by specifying a space separated list of tuples in the `GENTOO_CUSTOM_OVERLAYS` variable.  Each tuple is split by the first colon where the left side is the repo name and the right side is the sync-uri.  All custom overlays must be of the git type, similar to base overlays.

This also cleans up a few other issues:

1. Setting `GENTOO_PORTAGE_CLEANUP="True"`, which is the default, now removes the repos via `eselect-repository` instead of `layman`.  Repos are added via `eselect-repository` so it makes sense to keep this symmetric, especially since `layman` isn't installed by default anymore.
2. This also syncs base and custom overlays after adding them so you can actually install packages from these overlays
3. The `dist-kernel` USE flag is added to the defaults.  `dist-kernel-bin` is a default package so we should probably tell packages to actually use it.
4. Added a way to specify `ACCEPT_KEYWORDS`

One question I have though is how do you set `GENTOO_EMERGE_ENV`?  There doesn't seem to be a good way (that I could find) to export an entire bash array so everything I tried got overwritten by the defaults...

This was tested with the following script

```
#!/usr/bin/env bash
#  *   CONFIG_DM_MULTIPATH:        is not set when it should be.

set -e 

cwd=$(pwd)

pushd ~/Src/DiskImageBuilder

python -m venv venv

source venv/bin/activate

pip install -r requirements.txt

pip install -e .

# Default since 3.37
# export GENTOO_PROFILE="default/linux/amd64/23.0"

export GENTOO_OVERLAYS="steam-overlay supertux88 librewolf guru"
export GENTOO_CUSTOM_OVERLAYS="reavessm:https://gitlab.com/reavessm/gentoo-overlay"
export GENTOO_PORTAGE_CLEANUP="False"
export GENTOO_EMERGE_DEFAULT_OPTS="--binpkg-respect-use --rebuilt-binaries=y --usepkg=y --with-bdeps=y --binpkg-changed-deps=y --quiet" # --jobs=2 --autounmask=n"
export GENTOO_EMERGE_DEFAULT_OPTS="${GENTOO_EMERGE_DEFAULT_OPTS} -j8 --autounmask=y --autounmask-write --autounmask-continue"

declare -a profiles
profiles+=("default/linux/amd64/23.0/systemd")
profiles+=("default/linux/amd64/23.0/hardened/systemd")
# This fails for some reason...
# profiles+=("default/linux/amd64/23.0/hardened/selinux/systemd")

for prof in ${profiles[@]}
do
  echo "Building ${prof}"
  mkdir -pv "${cwd}/${prof}"
  export GENTOO_PROFILE="${prof}"

  export GENTOO_ACCEPT_KEYWORDS="~amd64"
  ./venv/bin/disk-image-create -o "${cwd}/${prof}/gentoo.qcow2" vm growroot gentoo -p app-editors/neovim
  ./venv/bin/disk-image-create -o "${cwd}/${prof}/gentoo-reavessm.qcow2" vm growroot gentoo -p acct-user/reavessm

  export GENTOO_ACCEPT_KEYWORDS=""
  ./venv/bin/disk-image-create -o "${cwd}/${prof}/gentoo-reavessm-zfs.qcow2" vm growroot gentoo -p acct-user/reavessm -p "\"sys-fs/zfs[rootfs]\"" -p "\"sys-fs/zfs-kmod[dist-kernel-cap\,rootfs]\""
done

popd
```